### PR TITLE
Add environment variable ANSIBLE_ROLES_PATH to integration test playbook

### DIFF
--- a/roles/run_integration_tests/defaults/main.yml
+++ b/roles/run_integration_tests/defaults/main.yml
@@ -1,0 +1,1 @@
+ANSIBLE_ROLES_PATH: "{{ integration_tests_path }}"

--- a/run_integration_tests.yaml
+++ b/run_integration_tests.yaml
@@ -39,5 +39,6 @@
         apply:
           environment:
             ANSIBLE_DEBUG_BOTOCORE_LOGS: True
+            ANSIBLE_ROLES_PATH: "{{ integration_tests_path }}"
       with_items:
         - "{{ _integration_targets }}"

--- a/run_integration_tests.yaml
+++ b/run_integration_tests.yaml
@@ -39,6 +39,5 @@
         apply:
           environment:
             ANSIBLE_DEBUG_BOTOCORE_LOGS: True
-            ANSIBLE_ROLES_PATH: "{{ integration_tests_path }}"
       with_items:
         - "{{ _integration_targets }}"


### PR DESCRIPTION
To enable running integration tests target as an ansible role, 
I am trying to add the ENV variable ANSIBLE_ROLES_PATH to the integration test playbook.